### PR TITLE
Support for more operators

### DIFF
--- a/Modula-2.tmLanguage
+++ b/Modula-2.tmLanguage
@@ -123,7 +123,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(\(|\)|\+|-|\*|/|:|;|\.|\^|=|:=)</string>
+			<string>(\(|\)|\+|-|\*|/|:|;|\.|\^|=|:=|&lt;|&gt;|#)</string>
 			<key>name</key>
 			<string>variable.parameter.function.modula2</string>
 		</dict>


### PR DESCRIPTION
Syntax highlighting for <, > and #, implying that comparison operators #, <>, <, >, <= and >= are highlighted.